### PR TITLE
Training data generation

### DIFF
--- a/scripts_data_processing/oxford/oxford_build_pointclouds.m
+++ b/scripts_data_processing/oxford/oxford_build_pointclouds.m
@@ -37,7 +37,7 @@ datasets = datasets.Var1;
 
 
 totalClouds = 0;
-for d = 2 : length(datasets)
+for d = 1 : length(datasets)
 
     if ~exist(fullfile(FOLDER, datasets{d}), 'dir')
         continue


### PR DESCRIPTION
Fixed the iterator to include the 2014-06-26-09-31-18 dataset, otherwise `oxford_generate_train_cases` fails.